### PR TITLE
Use lazy initialization for 'maxCombo'

### DIFF
--- a/src/com/rian/osu/beatmap/Beatmap.kt
+++ b/src/com/rian/osu/beatmap/Beatmap.kt
@@ -106,10 +106,11 @@ class Beatmap : Cloneable {
     /**
      * Gets the max combo of this beatmap.
      */
-    val maxCombo: Int
-        get() = hitObjects.getObjects().sumOf {
+    val maxCombo by lazy {
+        hitObjects.getObjects().sumOf {
             if (it is Slider) it.nestedHitObjects.size else 1
         }
+    }
 
     public override fun clone() =
         (super.clone() as Beatmap).apply {


### PR DESCRIPTION
The 'sumOf' operation should be done once if the 'maxCombo' is referenced.